### PR TITLE
Fix install of 1.2.1 on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 # allow setup.py to be run from any path
-os.chdir(Path(__file__).absolute().parent)
+os.chdir(str(Path(__file__).absolute().parent))
 
 if 'publish' in sys.argv:
     if 'test' in sys.argv:


### PR DESCRIPTION
I was getting error `TypeError: chdir() argument 1 must be string, not WindowsPath` trying to install on Python 2.7 on Windows using Pathlib 1.0.1. This issue might have existed with Pathlib.PosixPath objects on Linux too, I haven't checked, but this should fix that too.