### PR TITLE
Rename DebugPanel to Panel

### DIFF
--- a/src/mail_panel/panels.py
+++ b/src/mail_panel/panels.py
@@ -3,13 +3,13 @@ from django.utils.translation import ugettext_lazy as _
 from collections import OrderedDict
 import datetime
 
-from debug_toolbar.panels import DebugPanel
+from debug_toolbar.panels import Panel
 
 from .conf import MAIL_TOOLBAR_TTL
 from .utils import load_outbox, save_outbox
 from .urls import urlpatterns
 
-class MailToolbarPanel(DebugPanel):
+class MailToolbarPanel(Panel):
     """
     Panel that displays informations about mail
     """


### PR DESCRIPTION
I'm seeing lots of DeprecationWarnings in my test logs, I think it's down to DDT renaming their base panel class.

I've changed the name here but I've not tested it or anything. I'm assuming it's a drop in replacement. If this isn't the case I'm more than happy to put some actual time into a PR. This was just made using GitHub's in-browser editor.