### PR TITLE
add django-debug-toolbar 2.0 compatibility and fix tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 import os
-from pathlib import Path
 import sys
 from setuptools import setup, find_packages
 
 # allow setup.py to be run from any path
-os.chdir(str(Path(__file__).absolute().parent))
+os.chdir(os.path.abspath(os.path.dirname(os.path.realpath(__file__))))
 
 if 'publish' in sys.argv:
     if 'test' in sys.argv:

--- a/src/mail_panel/panels.py
+++ b/src/mail_panel/panels.py
@@ -3,13 +3,18 @@ from django.utils.translation import ugettext_lazy as _
 from collections import OrderedDict
 import datetime
 
-from debug_toolbar.panels import DebugPanel
+try:
+    from debug_toolbar.panels import Panel
+except ImportError:
+    # django-debug-toolbar 1.x back compatibility
+    from debug_toolbar.panels import DebugPanel as Panel
 
 from .conf import MAIL_TOOLBAR_TTL
 from .utils import load_outbox, save_outbox
 from .urls import urlpatterns
 
-class MailToolbarPanel(DebugPanel):
+
+class MailToolbarPanel(Panel):
     """
     Panel that displays informations about mail
     """
@@ -36,7 +41,7 @@ class MailToolbarPanel(DebugPanel):
     def title(self):
         return _('Mail')
 
-    def process_response(self, request, response):
+    def generate_stats(self, request, response):
         """
         Main panel view.  Loads and displays listing of mail.
         """
@@ -65,6 +70,13 @@ class MailToolbarPanel(DebugPanel):
         self.record_stats({
             'mail_list': self.mail_list,
         })
+
+    def process_response(self, request, response):
+        """
+        generate_stats replace process_response in django-debug-toolbar 2.0.
+        Call generate_stats for back compatibility.
+        """
+        self.generate_stats(request, response)
 
     @classmethod
     def get_urls(cls):

--- a/test_build.sh
+++ b/test_build.sh
@@ -4,11 +4,11 @@
 # Builds package and tests wheel in python 2 and 3
 # Add 2 or 3 to test a particular version of python
 
-python setup.py sdist bdist_wheel
+python3 setup.py sdist bdist_wheel
 
-DJANGO_SETTINGS_MODULE='tests.settings'
-COMMAND="from mail_panel.panels import MailToolbarPanel; MailToolbarPanel(object)"
-echo $COMMAND
+export DJANGO_SETTINGS_MODULE='tests.settings'
+TEST="tests"
+echo $TEST
 
 FILE=`ls -1 dist/*.whl | tail -n 1`
 echo "Verifying build of $FILE"
@@ -17,14 +17,26 @@ if [ -z "$1" ] || [ "$1" -eq "2" ]; then
     echo "# Installing virtualenv for Python 2"
     rm -rf 27-sdist  # ensure clean state if ran repeatedly
     virtualenv 27-sdist
+
+    echo "# Install Python 2 requirements"
     27-sdist/bin/pip install django $FILE
-    27-sdist/bin/python -c"$COMMAND"
+
+    echo "# Run command with Python 2"
+    27-sdist/bin/python -m "$TEST"
+
+    echo "# Test using Python 2 ended"
 fi
 
 if [ -z "$1" ] || [ "$1" -eq "3" ]; then
     echo "# Installing virtualenv for Python 3"
     rm -rf 3-sdist  # ensure clean state if ran repeatedly
     virtualenv -p python3 3-sdist
+
+    echo "# Install Python 3 requirements"
     3-sdist/bin/pip3 install django $FILE
-    3-sdist/bin/python3 -c"$COMMAND"
+
+    echo "# Run command with Python 3"
+    3-sdist/bin/python3 -m "$TEST"
+
+    echo "# Test using Python 3 ended"
 fi

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,0 +1,4 @@
+from .test_toolbar import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,21 +1,38 @@
 from .context import *
 
 import unittest
+import debug_toolbar
 from mail_panel.panels import MailToolbarPanel
 
+
 class ToolbarSuite(unittest.TestCase):
+    def setUp(self):
+        debug_toolbar_version = debug_toolbar.VERSION
+        
+        # django-debug-toolbar 1.x take 1 argument, 2.x take 2 arguments
+        self.panel_args = (None, None)
+        if debug_toolbar_version < '2.0':
+            self.panel_args = (None, )
 
     def test_panel(self):
         """
         General 'does it run' test.
         """
-        p = MailToolbarPanel(None)
-        assert(p.toolbar is None)
+        p = MailToolbarPanel(*self.panel_args)
+        self.assertIsNone(p.toolbar)
+
+    def test_generate_stats(self):
+        p = MailToolbarPanel(*self.panel_args)
+        p.generate_stats(None, None)
+
+    def test_process_response(self):
+        p = MailToolbarPanel(*self.panel_args)
+        p.process_response(None, None)
 
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(ToolbarSuite))
     return suite
 
-if __name__ == "__main__":
+def main():
     unittest.TextTestRunner().run(suite())


### PR DESCRIPTION
Hi!

I need to update some dependencies in my project but this awesome utility is not compatible with the latest version of `django-debug-toolbar` (*2.0* at this moment), so I made some fixes.

Bye.