### PR TITLE
fixe cannot serialize '_io.BufferedReader' object

### DIFF
--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -1,25 +1,62 @@
+import io
+import pickle
+
 from .context import *
 
 import unittest
 import debug_toolbar
+from debug_toolbar.toolbar import DebugToolbar
+from django.core import mail
+from mail_panel.backend import MailToolbarBackendEmail, MailToolbarBackend
 from mail_panel.panels import MailToolbarPanel
+
+from django.test.client import RequestFactory
+rf = RequestFactory()
+get_request = rf.get('/hello/')
+post_request = rf.post('/submit/', {'foo': 'bar'})
 
 
 class ToolbarSuite(unittest.TestCase):
     def setUp(self):
         debug_toolbar_version = debug_toolbar.VERSION
-        
+
+        self.request = rf.post('/submit/', {'foo': 'bar'})
+
         # django-debug-toolbar 1.x take 1 argument, 2.x take 2 arguments
-        self.panel_args = (None, None)
         if debug_toolbar_version < '2.0':
-            self.panel_args = (None, )
+            self.toolbar = DebugToolbar(self.request)
+            self.panel_args = (self.toolbar, )
+        else:
+            self.toolbar = DebugToolbar(self.request, None)
+            self.panel_args = (self.toolbar, None)
+
+    @staticmethod
+    def get_fake_message(
+            to=None,
+            cc=None,
+            bcc=None,
+            reply_to=None,
+            from_email=None,
+            body=None,
+            alternatives=None,
+    ):
+        # TODO Use Faker (https://github.com/joke2k/faker)
+        return mail.EmailMultiAlternatives(
+            to=to or ['to@fake.com'],
+            cc=cc or ['cc@fake.com'],
+            bcc=bcc or ['bcc@fake.com'],
+            reply_to=reply_to or ['reply_to@fake.com'],
+            from_email=from_email or 'from_email@fake.com',
+            body=body or 'body',
+            alternatives=alternatives or [('<b>HTML</b> body', 'text/html')],
+        )
 
     def test_panel(self):
         """
         General 'does it run' test.
         """
         p = MailToolbarPanel(*self.panel_args)
-        self.assertIsNone(p.toolbar)
+        self.assertEqual(p.toolbar, self.toolbar)
 
     def test_generate_stats(self):
         p = MailToolbarPanel(*self.panel_args)
@@ -29,10 +66,52 @@ class ToolbarSuite(unittest.TestCase):
         p = MailToolbarPanel(*self.panel_args)
         p.process_response(None, None)
 
+    def test_backend_email(self):
+        fake_message = self.get_fake_message()
+
+        # Create MailToolbarBackendEmail from fake EmailMultiAlternatives
+        message = MailToolbarBackendEmail(fake_message)
+
+        # Check email fields
+        self.assertEqual(message.to, fake_message.to)
+        self.assertEqual(message.cc, fake_message.cc)
+        self.assertEqual(message.bcc, fake_message.bcc)
+        self.assertEqual(message.reply_to, fake_message.reply_to)
+        self.assertEqual(message.from_email, fake_message.from_email)
+        self.assertEqual(message.body, fake_message.body)
+        self.assertEqual(message.alternatives, fake_message.alternatives)
+
+        # Check extra fields
+        self.assertIsNotNone(message.id)
+        self.assertIsNotNone(message.date_sent)
+        self.assertFalse(message.read)
+
+    def test_backend(self):
+        # Test with simple message
+        fake_message = self.get_fake_message()
+
+        backend = MailToolbarBackend()
+        backend.send_messages([fake_message])
+
+        # Test with not serializable message
+        fake_message = self.get_fake_message()
+        fake_message.not_serializable_field = io.BufferedReader(io.StringIO(u'initial text data'))
+
+        # BufferedReader is serializable in Python2
+        if sys.version_info[0] >= 3:
+            with self.assertRaises(TypeError):
+                pickle.dumps(fake_message, pickle.HIGHEST_PROTOCOL)
+
+        backend = MailToolbarBackend()
+        backend.send_messages([fake_message])
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(ToolbarSuite))
     return suite
 
+
 def main():
     unittest.TextTestRunner().run(suite())
+


### PR DESCRIPTION
Hi,
I had some problem using **django-mail-panel** with [Djoser](https://github.com/sunscrapers/djoser).

The reset password email (and other Djoser's emails) reference the request and during serialization raise an error:

```
Traceback (most recent call last):
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/rest_framework/viewsets.py", line 114, in view
    return self.dispatch(request, *args, **kwargs)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/rest_framework/views.py", line 497, in dispatch
    response = self.handle_exception(exc)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/rest_framework/views.py", line 457, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/rest_framework/views.py", line 468, in raise_uncaught_exception
    raise exc
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/rest_framework/views.py", line 494, in dispatch
    response = handler(request, *args, **kwargs)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/djoser/views.py", line 140, in perform_create
    settings.EMAIL.confirmation(self.request, context).send(to)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/templated_mail/mail.py", line 78, in send
    super(BaseEmailMessage, self).send(*args, **kwargs)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/django/core/mail/message.py", line 291, in send
    return self.get_connection(fail_silently).send_messages([self])
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/mail_panel/backend.py", line 36, in send_messages
    save_outbox(self.outbox)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/mail_panel/utils.py", line 15, in save_outbox
    cache.set(MAIL_TOOLBAR_CACHE_KEY, outbox, MAIL_TOOLBAR_TTL)
  File "/path/to/project/.virtualenv/lib/python3.7/site-packages/django/core/cache/backends/locmem.py", line 56, in set
    pickled = pickle.dumps(value, self.pickle_protocol)
TypeError: cannot serialize '_io.BufferedReader' object
```

Seems that `io.BufferedReader` raise serialization error only on Python 3.

In order to prevent this issue I have copied the required fields of the messages in a clean `EmailMultiAlternatives`.
