### PR TITLE
Fix missing subject

### DIFF
--- a/src/mail_panel/backend.py
+++ b/src/mail_panel/backend.py
@@ -17,6 +17,7 @@ class MailToolbarBackendEmail(mail.EmailMultiAlternatives):
         message.message()  # triggers header validation
 
         super(MailToolbarBackendEmail, self).__init__(
+            subject=message.subject,
             to=message.to,
             cc=message.cc,
             bcc=message.bcc,

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -32,6 +32,7 @@ class ToolbarSuite(unittest.TestCase):
 
     @staticmethod
     def get_fake_message(
+            subject=None,
             to=None,
             cc=None,
             bcc=None,
@@ -42,6 +43,7 @@ class ToolbarSuite(unittest.TestCase):
     ):
         # TODO Use Faker (https://github.com/joke2k/faker)
         return mail.EmailMultiAlternatives(
+            subject=subject or ['fake subject'],
             to=to or ['to@fake.com'],
             cc=cc or ['cc@fake.com'],
             bcc=bcc or ['bcc@fake.com'],
@@ -73,6 +75,7 @@ class ToolbarSuite(unittest.TestCase):
         message = MailToolbarBackendEmail(fake_message)
 
         # Check email fields
+        self.assertEqual(message.subject, fake_message.subject)
         self.assertEqual(message.to, fake_message.to)
         self.assertEqual(message.cc, fake_message.cc)
         self.assertEqual(message.bcc, fake_message.bcc)

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -43,7 +43,7 @@ class ToolbarSuite(unittest.TestCase):
     ):
         # TODO Use Faker (https://github.com/joke2k/faker)
         return mail.EmailMultiAlternatives(
-            subject=subject or ['fake subject'],
+            subject=subject or 'fake subject',
             to=to or ['to@fake.com'],
             cc=cc or ['cc@fake.com'],
             bcc=bcc or ['bcc@fake.com'],


### PR DESCRIPTION
When the last refactoring was made the subject from the emails went missing. I've added them here and verified that it works for Django 2.2 and python3.

I have not been able to run the tests due to lack of instructions for running them and unable to run the test_build.sh script on my computer.

Please let me know if there is anything else I can help you with regarding this PR!

Great library btw!