### PR TITLE
Add in a utility function to clear out emails

### DIFF
--- a/src/mail_panel/utils.py
+++ b/src/mail_panel/utils.py
@@ -13,3 +13,9 @@ def save_outbox(outbox):
     Saves the dictionary of cached mail and sets expiry.
     """
     cache.set(MAIL_TOOLBAR_CACHE_KEY, outbox, MAIL_TOOLBAR_TTL)
+    
+def clear_outbox():
+    """
+    Utility function to clear the dictionary of cached mail. Typical use case: Starting a new real-human test session.
+    """
+    cache.set(MAIL_TOOLBAR_CACHE_KEY, {})


### PR DESCRIPTION
Having this utility function is useful so the list of sent emails can be cleared out when starting a Real Human test run.