### PR TITLE
Make the datetime timezone aware

### DIFF
--- a/mail_panel/backend.py
+++ b/mail_panel/backend.py
@@ -1,5 +1,6 @@
 from django.core import mail
 from django.core.mail.backends.locmem import EmailBackend
+from django.utils.timezone import now
 import datetime
 from uuid import uuid4
 
@@ -12,7 +13,7 @@ class MailToolbarBackendEmail(mail.EmailMultiAlternatives):
             self.id = uuid4().get_hex()
         except AttributeError:
             self.id = uuid4().hex  # python 3
-        self.date_sent = datetime.datetime.now()
+        self.date_sent = now()
         self.read = False
         message.message()  # triggers header validation
 


### PR DESCRIPTION
When listing emails, currently they all show as being sent as if they were in GMT. This should allow the time of recording to have the `tzinfo` populated and therefore should show up properly.