### PR TITLE
Show any extra headers that have been added

### DIFF
--- a/mail_panel/backend.py
+++ b/mail_panel/backend.py
@@ -26,6 +26,7 @@ class MailToolbarBackendEmail(mail.EmailMultiAlternatives):
             from_email=message.from_email,
             body=message.body,
             alternatives=message.alternatives,
+            headers=message.extra_headers,
         )
 
 

--- a/mail_panel/static/debug_toolbar/mail/mail_toolbar.css
+++ b/mail_panel/static/debug_toolbar/mail/mail_toolbar.css
@@ -81,6 +81,10 @@
 	float: right;
 	color: #888 !important;
 }
+#djDebug .djm-mail-toolbar .djm-extra-headers{
+	border-top: 1px solid #f5f5f5;
+	color: #888 !important;
+}
 #djDebug .djm-mail-toolbar #djm_message_overview{
 	border-bottom: 1px solid #f5f5f5;
 	position:relative;

--- a/mail_panel/templates/mail_panel/message_overview.html
+++ b/mail_panel/templates/mail_panel/message_overview.html
@@ -16,6 +16,13 @@
         {{message.bcc}}<br>
     {% endif %}
     {{message.subject}}<br>
+    {% if message.extra_headers %}
+        <div class='djm-extra-headers'>
+            {% for header, value in message.extra_headers.items %}
+                {{header}}: {{value}}<br>
+            {% endfor %}
+        </div>
+    {% endif %}
 
     {% if message.attachments %}
     <div class='djm-no-select'>

--- a/tests/test_toolbar.py
+++ b/tests/test_toolbar.py
@@ -41,6 +41,7 @@ class ToolbarSuite(unittest.TestCase):
             from_email=None,
             body=None,
             alternatives=None,
+            headers=None,
     ):
         # TODO Use Faker (https://github.com/joke2k/faker)
         return mail.EmailMultiAlternatives(
@@ -52,6 +53,7 @@ class ToolbarSuite(unittest.TestCase):
             from_email=from_email or 'from_email@fake.com',
             body=body or 'body',
             alternatives=alternatives or [('<b>HTML</b> body', 'text/html')],
+            headers=headers or {'X-MyHeader': 'myheader'}
         )
 
     def test_panel(self):
@@ -101,6 +103,7 @@ class ToolbarSuite(unittest.TestCase):
         self.assertEqual(message.from_email, fake_message.from_email)
         self.assertEqual(message.body, fake_message.body)
         self.assertEqual(message.alternatives, fake_message.alternatives)
+        self.assertEqual(message.extra_headers, fake_message.extra_headers)
 
         # Check extra fields
         self.assertIsNotNone(message.id)


### PR DESCRIPTION
It is common to add extra headers to an email so for auditing, debugging, and for users to create inbox rules. I would find it helpful if those showed up in the mail panel.

Below is a screenshot of how I implemented it. I tried to follow the look and feel and coding style of the project, but please tweak it if you are not totally happy with it.

![show-extra-headers](https://user-images.githubusercontent.com/21705/119754993-860af380-be5e-11eb-9600-54738f0b0b36.png)

Thanks for making mail panel — it is super helpful!