### PR TITLE
Add tab for viewing the raw message

### DIFF
--- a/mail_panel/static/debug_toolbar/mail/mail_toolbar.css
+++ b/mail_panel/static/debug_toolbar/mail/mail_toolbar.css
@@ -108,10 +108,16 @@
 	color: black;
 }
 
-#djDebug .djm-mail-toolbar #plain_text_message{
-	font-family: sans-serif;
+#djDebug .djm-mail-toolbar #plain_text_message,
+#djDebug .djm-mail-toolbar #raw_message{
 	font-size: 12px;
 	margin: 10px 0px;
+}
+#djDebug .djm-mail-toolbar #plain_text_message{
+	font-family: sans-serif;
+}
+#djDebug .djm-mail-toolbar #raw_message{
+	font-family: monospace;
 }
 #djDebug .djm-mail-toolbar span.djm-attachment-group{
 	margin-right: 10px;

--- a/mail_panel/templates/mail_panel/raw_message.html
+++ b/mail_panel/templates/mail_panel/raw_message.html
@@ -1,0 +1,9 @@
+{% load static %}
+<link rel="stylesheet" href="{% static 'debug_toolbar/mail/mail_toolbar.css' %}" type="text/css"/>
+<div id='djDebug'>
+<div class='djm-mail-toolbar'>
+<div id='raw_message'>
+<pre>{{body|linebreaksbr}}</pre>
+</div>
+</div>
+</div>

--- a/mail_panel/views.py
+++ b/mail_panel/views.py
@@ -59,16 +59,16 @@ def display_multipart(request, message_id, multipart):
         elif hasattr(message, "alternatives"):
             for alternative in message.alternatives:
                 if alternative[1] == multipart:
-                    body = mark_safe(alternative[0].replace("<a ", "<a target='_blank'"))
+                    body = mark_safe(alternative[0].replace("<a ", "<a target='_blank' "))
                     return HttpResponse(body)
         else:
-            body = mark_safe(message.body.replace("<a ", "<a target='_blank'"))
+            body = mark_safe(message.body.replace("<a ", "<a target='_blank' "))
             return HttpResponse(body)
 
 
     return render(request, "mail_panel/plain_text_message.html", dict(
         body=mark_safe(
-            urlize(message.body).replace("<a ", "<a target='_blank'"))
+            urlize(message.body).replace("<a ", "<a target='_blank' "))
     ))
 
 

--- a/mail_panel/views.py
+++ b/mail_panel/views.py
@@ -20,7 +20,7 @@ def load_message(request, message_id):
     mail_list = load_outbox()
     message = mail_list.get(message_id, None)
 
-    alternatives = list()
+    alternatives = ["message/rfc822"]
     if message:
         message.read = True
 
@@ -52,7 +52,11 @@ def display_multipart(request, message_id, multipart):
         return HttpResponse('Messsage has expired from cache.')
 
     if multipart not in ('', 'text/plain'):
-        if hasattr(message, "alternatives"):
+        if multipart == "message/rfc822":
+            return render(request, "mail_panel/raw_message.html", dict(
+                body=message.message().as_string())
+            )
+        elif hasattr(message, "alternatives"):
             for alternative in message.alternatives:
                 if alternative[1] == multipart:
                     body = mark_safe(alternative[0].replace("<a ", "<a target='_blank'"))


### PR DESCRIPTION
I recently wanted to inspect the HTML and headers of emails I was testing, so I added the ability to view that.

![show-raw-message](https://user-images.githubusercontent.com/21705/119755748-bc953e00-be5f-11eb-8b1f-04a24af5b38f.png)

Is this a feature that would be welcome in the project?