### PR TITLE
Add attachments to email message (Fixes #36)

### DIFF
--- a/mail_panel/backend.py
+++ b/mail_panel/backend.py
@@ -27,6 +27,7 @@ class MailToolbarBackendEmail(mail.EmailMultiAlternatives):
             body=message.body,
             alternatives=message.alternatives,
             headers=message.extra_headers,
+            attachments=message.attachments,
         )
 
 


### PR DESCRIPTION
Currently the 'attachments' property is not forwarded to the EmailMessage. This PR will pass it on, enabling the nice 'download attachment' feature in the debug panel :-)